### PR TITLE
Removed text selection for paralax elements

### DIFF
--- a/src/components/Skills/Skills.js
+++ b/src/components/Skills/Skills.js
@@ -46,15 +46,15 @@ const WordClouds = () => {
       aria-hidden="true"
       className="skills__word-clouds"
     >
-      <p style={{ top: 50, left: '100%', fontSize: 23 }}>HTML5</p>
-      <p style={{ top: 0, left: 0, fontSize: 25 }}>WebGL</p>
-      <p style={{ top: 200, left: -60, fontSize: 14 }}>CSS3</p>
-      <p style={{ top: '30%', left: '35%', fontSize: 18 }}>figma</p>
-      <p style={{ top: 40, left: '75%', fontSize: 12 }}>antd</p>
-      <p style={{ top: 380, left: '85%', fontSize: 18 }}>MongoDB</p>
-      <p style={{ top: 320, left: '65%', fontSize: 18 }}>Gatsby</p>
-      <p style={{ top: 350, left: 150, fontSize: 20 }}>ES6</p>
-      <p style={{ top: 120, left: '22%', fontSize: 12 }}>blender</p>
+      <p style={{ top: 50, left: '100%', fontSize: 23 }} className="no-select">HTML5</p>
+      <p style={{ top: 0, left: 0, fontSize: 25 }} className="no-select">WebGL</p>
+      <p style={{ top: 200, left: -60, fontSize: 14 }} className="no-select">CSS3</p>
+      <p style={{ top: '30%', left: '35%', fontSize: 18 }} className="no-select">figma</p>
+      <p style={{ top: 40, left: '75%', fontSize: 12 }} className="no-select">antd</p>
+      <p style={{ top: 380, left: '85%', fontSize: 18 }} className="no-select">MongoDB</p>
+      <p style={{ top: 320, left: '65%', fontSize: 18 }} className="no-select">Gatsby</p>
+      <p style={{ top: 350, left: 150, fontSize: 20 }} className="no-select">ES6</p>
+      <p style={{ top: 120, left: '22%', fontSize: 12 }} className="no-select">blender</p>
     </Parallax>
   );
 };

--- a/src/components/Skills/Skills.js
+++ b/src/components/Skills/Skills.js
@@ -46,15 +46,15 @@ const WordClouds = () => {
       aria-hidden="true"
       className="skills__word-clouds"
     >
-      <p style={{ top: 50, left: '100%', fontSize: 23 }} className="no-select">HTML5</p>
-      <p style={{ top: 0, left: 0, fontSize: 25 }} className="no-select">WebGL</p>
-      <p style={{ top: 200, left: -60, fontSize: 14 }} className="no-select">CSS3</p>
-      <p style={{ top: '30%', left: '35%', fontSize: 18 }} className="no-select">figma</p>
-      <p style={{ top: 40, left: '75%', fontSize: 12 }} className="no-select">antd</p>
-      <p style={{ top: 380, left: '85%', fontSize: 18 }} className="no-select">MongoDB</p>
-      <p style={{ top: 320, left: '65%', fontSize: 18 }} className="no-select">Gatsby</p>
-      <p style={{ top: 350, left: 150, fontSize: 20 }} className="no-select">ES6</p>
-      <p style={{ top: 120, left: '22%', fontSize: 12 }} className="no-select">blender</p>
+      <p style={{ top: 50, left: '100%', fontSize: 23, WebkitTouchCallout: "none", WebkitUserSelect: "none", userSelect: "none", msUserSelect: "none" }}>HTML5</p>
+      <p style={{ top: 0, left: 0, fontSize: 25, WebkitTouchCallout: "none", WebkitUserSelect: "none", userSelect: "none", msUserSelect: "none" }}>WebGL</p>
+      <p style={{ top: 200, left: -60, fontSize: 14, WebkitTouchCallout: "none", WebkitUserSelect: "none", userSelect: "none", msUserSelect: "none" }}>CSS3</p>
+      <p style={{ top: '30%', left: '35%', fontSize: 18, WebkitTouchCallout: "none", WebkitUserSelect: "none", userSelect: "none", msUserSelect: "none" }}>figma</p>
+      <p style={{ top: 40, left: '75%', fontSize: 12, WebkitTouchCallout: "none", WebkitUserSelect: "none", userSelect: "none", msUserSelect: "none" }}>antd</p>
+      <p style={{ top: 380, left: '85%', fontSize: 18, WebkitTouchCallout: "none", WebkitUserSelect: "none", userSelect: "none", msUserSelect: "none" }}>MongoDB</p>
+      <p style={{ top: 320, left: '65%', fontSize: 18, WebkitTouchCallout: "none", WebkitUserSelect: "none", userSelect: "none", msUserSelect: "none" }}>Gatsby</p>
+      <p style={{ top: 350, left: 150, fontSize: 20, WebkitTouchCallout: "none", WebkitUserSelect: "none", userSelect: "none", msUserSelect: "none" }}>ES6</p>
+      <p style={{ top: 120, left: '22%', fontSize: 12, WebkitTouchCallout: "none", WebkitUserSelect: "none", userSelect: "none", msUserSelect: "none" }}>blender</p>
     </Parallax>
   );
 };

--- a/src/components/Skills/Skills.js
+++ b/src/components/Skills/Skills.js
@@ -33,6 +33,7 @@ const SkillsWrapper = styled.section`
       left: 0;
       right: 0;
       font-weight: 900;
+      user-select: none;
     }
     z-index: -1;
   }
@@ -46,15 +47,15 @@ const WordClouds = () => {
       aria-hidden="true"
       className="skills__word-clouds"
     >
-      <p style={{ top: 50, left: '100%', fontSize: 23, WebkitTouchCallout: "none", WebkitUserSelect: "none", userSelect: "none", msUserSelect: "none" }}>HTML5</p>
-      <p style={{ top: 0, left: 0, fontSize: 25, WebkitTouchCallout: "none", WebkitUserSelect: "none", userSelect: "none", msUserSelect: "none" }}>WebGL</p>
-      <p style={{ top: 200, left: -60, fontSize: 14, WebkitTouchCallout: "none", WebkitUserSelect: "none", userSelect: "none", msUserSelect: "none" }}>CSS3</p>
-      <p style={{ top: '30%', left: '35%', fontSize: 18, WebkitTouchCallout: "none", WebkitUserSelect: "none", userSelect: "none", msUserSelect: "none" }}>figma</p>
-      <p style={{ top: 40, left: '75%', fontSize: 12, WebkitTouchCallout: "none", WebkitUserSelect: "none", userSelect: "none", msUserSelect: "none" }}>antd</p>
-      <p style={{ top: 380, left: '85%', fontSize: 18, WebkitTouchCallout: "none", WebkitUserSelect: "none", userSelect: "none", msUserSelect: "none" }}>MongoDB</p>
-      <p style={{ top: 320, left: '65%', fontSize: 18, WebkitTouchCallout: "none", WebkitUserSelect: "none", userSelect: "none", msUserSelect: "none" }}>Gatsby</p>
-      <p style={{ top: 350, left: 150, fontSize: 20, WebkitTouchCallout: "none", WebkitUserSelect: "none", userSelect: "none", msUserSelect: "none" }}>ES6</p>
-      <p style={{ top: 120, left: '22%', fontSize: 12, WebkitTouchCallout: "none", WebkitUserSelect: "none", userSelect: "none", msUserSelect: "none" }}>blender</p>
+      <p style={{ top: 50, left: '100%', fontSize: 23 }}>HTML5</p>
+      <p style={{ top: 0, left: 0, fontSize: 25 }}>WebGL</p>
+      <p style={{ top: 200, left: -60, fontSize: 14 }}>CSS3</p>
+      <p style={{ top: '30%', left: '35%', fontSize: 18 }}>figma</p>
+      <p style={{ top: 40, left: '75%', fontSize: 12 }}>antd</p>
+      <p style={{ top: 380, left: '85%', fontSize: 18 }}>MongoDB</p>
+      <p style={{ top: 320, left: '65%', fontSize: 18 }}>Gatsby</p>
+      <p style={{ top: 350, left: 150, fontSize: 20 }}>ES6</p>
+      <p style={{ top: 120, left: '22%', fontSize: 12 }}>blender</p>
     </Parallax>
   );
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/69592270/100958424-489a5e80-34ea-11eb-8694-fae63e7aeba7.png)

Right now, you can select all the text from the `p`. This fixes it for all modern browsers.


Note, the no select classname thing was a mistake I made at first, wasn't the best approach to this.