### PR TITLE
fix: Make logo click always navigate to "/"

### DIFF
--- a/src/components/Layout/Navbar/NavDesktop.js
+++ b/src/components/Layout/Navbar/NavDesktop.js
@@ -12,8 +12,10 @@ import ToggleSwitch from '@common/ToggleSwitch';
 const NavDesktop = () => {
   return (
     <>
-      <SLink className="logo" smooth offset={-100} hashSpy={true} to="home">
-        <img src={logo} alt="Anurag Hazra" />
+      <SLink smooth offset={-100} hashSpy={true} to="home">
+        <Link className="logo" to="/">
+          <img src={logo} alt="Anurag Hazra" />
+        </Link>
       </SLink>
 
       <nav>


### PR DESCRIPTION
This PR is to improve the UX of the website.

**What is the UX being fixed?**
One unwritten rule for any website is — "A click on the logo, on any page, should always navigate the user to the home page"


---


## Present behaviour

| Page the user is on | Behaviour on clicking the logo |
| --- | --- |
| `/` | Scrolls up to the first section ✅ |
| `/blog` | Does nothing ❌ |

---

## Suggested behaviour

| Page the user is on | Behaviour on clicking the logo |
| --- | --- |
| `/` | Scrolls up to the first section ✅ |
| `/blog` | Navigates to `/` ✅  |


---


Thanks to [@Vallari](https://github.com/VallariAg) for giving me the courage to raise a public PR! :raised_hands: 

@anuraghazra 